### PR TITLE
Fix training loop and tokenizer use

### DIFF
--- a/JAX-implementation/test.py
+++ b/JAX-implementation/test.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from flax.training import train_state
+from transformers import AutoTokenizer
 
 def command_based_fdm_test(model, test_data, command, params):
     interruptions = 0
@@ -54,6 +55,7 @@ def analyze_turn_taking(model, test_data, params):
     print(f"F1 Score: {f1_score:.4f}")
 
 def generate_speech(model, text, params):
-    tokenized_text = model.speaking_encoder.tokenizer(text, return_tensors="jax").input_values
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+    tokenized_text = tokenizer(text, return_tensors="jax").input_ids
     generated_audio = model.apply(params, tokenized_text, is_training=False, method=model.generate)
     return np.array(jax.device_get(generated_audio))

--- a/Tenserflow-implementation/test.py
+++ b/Tenserflow-implementation/test.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+from transformers import AutoTokenizer
 
 def command_based_fdm_test(model, test_data, command):
     interruptions = 0
@@ -53,6 +54,7 @@ def analyze_turn_taking(model, test_data):
     print(f"F1 Score: {f1_score:.4f}")
 
 def generate_speech(model, text):
-    tokenized_text = model.speaking_encoder.tokenizer(text, return_tensors="tf").input_values
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+    tokenized_text = tokenizer(text, return_tensors="tf").input_ids
     generated_audio = model.generate(tokenized_text)
     return generated_audio.numpy()

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import torchaudio
 from typing import List, Tuple
 from model import LSLM
 from dataset import LSLMDataset, collate_fn
+from transformers import AutoTokenizer
 from train import train, evaluate
 from visualization import visualize_attention, visualize_quantization
 from tests import command_based_fdm_test, voice_based_fdm_test, analyze_turn_taking, generate_speech
@@ -65,7 +66,8 @@ def main() -> None:
 
     # Command-based FDM test
     command_test_data: List[Tuple[torch.Tensor, str]] = [(torch.randn(MAX_AUDIO_LENGTH * SAMPLE_RATE), "Honey") for _ in range(100)]
-    command: torch.Tensor = model.speaking_encoder.tokenizer("Honey", return_tensors="pt").input_values.to(device)
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+    command: torch.Tensor = tokenizer("Honey", return_tensors="pt").input_ids.to(device)
     command_based_fdm_test(model, command_test_data, command, device)
 
     # Voice-based FDM test

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import torch
+from transformers import AutoTokenizer
 
 def command_based_fdm_test(model, test_data, command, device):
     model.eval()
@@ -58,6 +59,7 @@ def analyze_turn_taking(model, test_data, device):
 def generate_speech(model, text, device):
     model.eval()
     with torch.no_grad():
-        tokenized_text = model.speaking_encoder.tokenizer(text, return_tensors="pt").input_values.to(device)
+        tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+        tokenized_text = tokenizer(text, return_tensors="pt").input_ids.to(device)
         generated_audio = model.generate(tokenized_text)
         return generated_audio.cpu().numpy()

--- a/train.py
+++ b/train.py
@@ -6,11 +6,11 @@ def train(model, dataloader, optimizer, criterion, device, num_epochs):
     for epoch in range(num_epochs):
         total_loss = 0
         for batch in tqdm(dataloader, desc=f"Epoch {epoch+1}/{num_epochs}"):
-            tts_samples, combined_audios, tokenized_texts = [b.to(device) for b in batch]
+            combined_audios, tokenized_texts = [b.to(device) for b in batch]
             
             optimizer.zero_grad()
             output = model(tokenized_texts, combined_audios)
-            loss = criterion(output.view(-1, output.size(-1)), tts_samples.view(-1))
+            loss = criterion(output.view(-1, output.size(-1)), tokenized_texts.view(-1))
             loss.backward()
             optimizer.step()
             
@@ -24,10 +24,10 @@ def evaluate(model, dataloader, criterion, device):
     total_loss = 0
     with torch.no_grad():
         for batch in dataloader:
-            tts_samples, combined_audios, tokenized_texts = [b.to(device) for b in batch]
+            combined_audios, tokenized_texts = [b.to(device) for b in batch]
             
             output = model(tokenized_texts, combined_audios, is_training=False)
-            loss = criterion(output.view(-1, output.size(-1)), tts_samples.view(-1))
+            loss = criterion(output.view(-1, output.size(-1)), tokenized_texts.view(-1))
             total_loss += loss.item()
     
     return total_loss / len(dataloader)

--- a/visualization.py
+++ b/visualization.py
@@ -2,14 +2,31 @@ import torch
 import matplotlib.pyplot as plt
 
 def visualize_attention(model, sample_input):
-    attention_weights = model.decoder.transformer_decoder.layers[-1].self_attn.attention_weights
-    plt.figure(figsize=(10, 10))
-    plt.imshow(attention_weights.cpu().numpy(), cmap='viridis')
-    plt.title('Attention Weights Visualization')
-    plt.xlabel('Query')
-    plt.ylabel('Key')
-    plt.colorbar()
-    plt.show()
+    model.eval()
+    with torch.no_grad():
+        audio_features, tokenized_text = sample_input
+        device = next(model.parameters()).device
+        audio_features = audio_features.to(device)
+        tokenized_text = tokenized_text.to(device)
+
+        speaking_feats = model.speaking_encoder(tokenized_text)
+        listening_feats = model.listening_encoder(audio_features)
+        fused = model.fusion_module(speaking_feats, listening_feats)
+
+        layer = model.decoder.transformer_decoder.layers[-1]
+        attn_output, attn_weights = layer.self_attn(
+            fused.transpose(0, 1), fused.transpose(0, 1), fused.transpose(0, 1),
+            need_weights=True
+        )
+        attn = attn_weights.mean(dim=0).cpu().numpy()
+
+        plt.figure(figsize=(10, 10))
+        plt.imshow(attn, cmap='viridis')
+        plt.title('Attention Weights Visualization')
+        plt.xlabel('Query')
+        plt.ylabel('Key')
+        plt.colorbar()
+        plt.show()
 
 def visualize_quantization(model, audio_sample):
     model.eval()


### PR DESCRIPTION
## Summary
- align dataset outputs with training loop expectations
- instantiate tokenizers directly in test and main utilities
- compute attention weights correctly for visualization
- update examples in JAX and Tensorflow tests

## Testing
- `python -m py_compile dataset.py train.py model.py tests.py main.py visualization.py JAX-implementation/test.py Tenserflow-implementation/test.py`

------
https://chatgpt.com/codex/tasks/task_e_6841dccc24dc8326b10e86175d6e5b1d